### PR TITLE
Fix problem with exceptions on tests: use postgres attributes only if available

### DIFF
--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -25,15 +25,13 @@ def run_tests(path, conn, replaces):
             conn.commit()
             cursor.close()
             tests['ok'] += 1
-        except (psycopg2.Error) as e:
+        except Exception as e:
             print_error("Error running test %s" % file)
-            print_error(e.pgcode)
-            print_error(e.pgerror)
-            conn.rollback()
-            tests['errors'] += 1
-        except (Exception) as e:
-            print_error("Error running test %s" % file)
-            print_error(e)
+            try:
+                print_error(e.pgcode)
+                print_error(e.pgerror)
+            except:
+                print_error(e)
             conn.rollback()
             tests['errors'] += 1
         f.close()


### PR DESCRIPTION
There was a problem in the way we caught exceptions at the test scripts, as postgres error attributes were used even when it was not possible (therefore masking exceptions).

See example at https://jenkins.juliogonzalez.es/job/tds_fdw-build/PG_VER=9.5,label=centos6/159/console

Now we show postgres error attributes if available, or just the error otherwise.

Tested at https://jenkins.juliogonzalez.es/job/tds_fdw-build-ng/PG_VER=9.5,label=centos6/1/console